### PR TITLE
refactor: Use stdlib dataclasses

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,40 @@
+name: Build Sphinx documentation
+
+on: ["pull_request", "push"]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: "pyproject.toml"
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+          version: 0.6.12
+      - name: Install package and dependencies
+        run: |
+          uv sync --group doc
+      - name: Make gh-pages branch available
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: build/html
+      - name: Build documentation
+        run: |
+          source .venv/bin/activate
+          sphinx-build --doctree-dir build/doctrees --nitpicky doc build/html
+      - name: Deploy to GitHub Pages
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          pushd build/html
+          git add --all .
+          git commit -m "Built from ${GITHUB_REF}"
+          git push --force || :

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,4 @@
+project = "penelopise"
+author = "James Rowe"
+copyright = f"2024-2025, {author}"
+release = "0.1.0"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,14 @@
+``penelopise``
+==============
+
+The ``penelopise`` module is *mostly* functional Python library for
+parsing and working with `todo.txt`_ formatted files.
+
+This project is mostly a toy, but don't let that fool you — it’s reasonably
+well-tested and somewhat reliable for everyday use.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+.. _todo.txt: https://todotxt.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
   "Topic :: Text Processing :: Filters",
   "Topic :: Text Processing :: Markup",
 ]
-dependencies = ["attrs>=23.2.0"]
 
 [project.urls]
 "Source code" = "https://github.com/JNRowe/penelopise"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = ["pytest>=8.0"]
+doc = ["sphinx>=8.0"]
 lint = ["ruff>=0.4"]
 
 [tool.pytest.ini_options]

--- a/src/penelopise/__init__.py
+++ b/src/penelopise/__init__.py
@@ -1,10 +1,9 @@
 """penelopise - Basic parsing for ``todo.txt`` files."""
 
+import dataclasses
 import datetime
 import enum
 import re
-
-from attrs import define
 
 
 # Regular expression pattern for matching a string that *may* be an ISO-8601
@@ -24,7 +23,7 @@ arrangement respectively.
 """
 
 
-@define
+@dataclasses.dataclass(frozen=True)
 class Context:
     """Represent a context associated with a task.
 
@@ -36,7 +35,7 @@ class Context:
     name: str
 
 
-@define
+@dataclasses.dataclass(frozen=True)
 class Project:
     """Represent a project associated with a task.
 
@@ -47,7 +46,7 @@ class Project:
     name: str
 
 
-@define
+@dataclasses.dataclass
 class Entry:
     """Represent a task.
 
@@ -57,13 +56,15 @@ class Entry:
     """
 
     text: str
-    complete: bool = False
-    completion_date: datetime.date | None = None
-    creation_date: datetime.date | None = None
-    priority: Priority | None = None
-    contexts: list[Context] = []
-    projects: list[Project] = []
-    attrs: dict[str, str | datetime.date] = {}
+    complete: bool = dataclasses.field(default=False)
+    completion_date: datetime.date | None = dataclasses.field(default=None)
+    creation_date: datetime.date | None = dataclasses.field(default=None)
+    priority: Priority | None = dataclasses.field(default=None)
+    contexts: list[Context] = dataclasses.field(default_factory=list)
+    projects: list[Project] = dataclasses.field(default_factory=list)
+    attrs: dict[str, str | datetime.date] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 def parse_entry(text: str) -> Entry:


### PR DESCRIPTION
This removes the only external dependency, and we’re not using any of the advanced functionality that `attrs` provides anyway.

`attrs` is such a common dependency in projects I use that it'll come back in a second if the situation arises.
