### PR TITLE
Property rework

### DIFF
--- a/src/penelopise/__init__.py
+++ b/src/penelopise/__init__.py
@@ -53,6 +53,13 @@ class Entry:
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}({self.text!r})"
 
+    def __setattr__(self, name, value):
+        if isinstance(
+            getattr(type(self), name, None), functools.cached_property
+        ):
+            raise AttributeError(f"Cannot set attribute '{name}'.")
+        super().__setattr__(name, value)
+
     @property
     def text(self) -> str:
         return self._text

--- a/src/penelopise/__init__.py
+++ b/src/penelopise/__init__.py
@@ -48,10 +48,29 @@ class Entry:
     """
 
     def __init__(self, text: str) -> None:
-        self.text = text
+        self._text = text
 
     def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}({self.text!r})"
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    @text.setter
+    def text(self, value: str) -> None:
+        if value != self._text:
+            self._text = value
+            for attr in (
+                "complete",
+                "completion_date",
+                "creation_date",
+                "priority",
+                "contexts",
+                "projects",
+                "attrs",
+            ):
+                self.__dict__.pop(attr, None)
 
     @functools.cached_property
     def complete(self) -> bool:

--- a/src/penelopise/__init__.py
+++ b/src/penelopise/__init__.py
@@ -1,6 +1,5 @@
 """penelopise - Basic parsing for ``todo.txt`` files."""
 
-import dataclasses
 import datetime
 import enum
 import functools
@@ -39,7 +38,6 @@ group tasks under a common goal or initiative.
 """
 
 
-@dataclasses.dataclass
 @functools.total_ordering
 class Entry:
     """Represent a task.
@@ -49,53 +47,63 @@ class Entry:
     projects.
     """
 
-    text: str
-    complete: bool = dataclasses.field(default=False, init=False)
-    completion_date: datetime.date | None = dataclasses.field(
-        default=None, init=False
-    )
-    creation_date: datetime.date | None = dataclasses.field(
-        default=None, init=False
-    )
-    priority: Priority | None = dataclasses.field(default=None, init=False)
-    contexts: list[Context] = dataclasses.field(
-        default_factory=list, init=False
-    )
-    projects: list[Project] = dataclasses.field(
-        default_factory=list, init=False
-    )
-    attrs: dict[str, str | datetime.date] = dataclasses.field(
-        default_factory=dict, init=False
-    )
+    def __init__(self, text: str) -> None:
+        self.text = text
 
-    def __post_init__(self) -> None:
-        """Parse a singular task string."""
+    def __repr__(self) -> str:
+        return f"{self.__class__.__qualname__}({self.text!r})"
+
+    @functools.cached_property
+    def complete(self) -> bool:
+        return self.text.startswith("x ")
+
+    @functools.cached_property
+    def completion_date(self) -> datetime.date | None:
         if m := re.match(
-            rf"x (?:\([A-Z]\) )?(?:({_ISO_DATE}) (?: {_ISO_DATE})?)?", self.text
+            rf"x (?:\([A-Z]\) )?(?:({_ISO_DATE})(?: {_ISO_DATE})?)?", self.text
         ):
-            self.complete = True
             if m.lastindex:
-                self.completion_date = datetime.date.fromisoformat(m.group(1))
-        if m := re.match(r"(?:x )?\(([A-Z])\) ", self.text):
-            self.priority = Priority[m.group(1)]
+                return datetime.date.fromisoformat(m.group(1))
+        return None
+
+    @functools.cached_property
+    def creation_date(self) -> datetime.date | None:
         if m := re.match(
             rf"(?:x {_ISO_DATE} |\([A-Z]\) )?({_ISO_DATE}) ", self.text
         ):
-            self.creation_date = datetime.date.fromisoformat(m.group(1))
-        for t, v in re.findall(r"\B([@\+])(\S+)\b", self.text):
-            if t == "@":
-                self.contexts.append(Context(v))
-            else:
-                self.projects.append(Project(v))
+            return datetime.date.fromisoformat(m.group(1))
+        else:
+            return None
+
+    @functools.cached_property
+    def priority(self) -> Priority | None:
+        if m := re.match(r"(?:x )?\(([A-Z])\) ", self.text, re.ASCII):
+            return Priority[m.group(1)]
+        elif m := re.search(r"\bpri:([A-Z])\b", self.text):
+            return Priority[m.group(1)]
+        else:
+            return None
+
+    @functools.cached_property
+    def contexts(self) -> list[Context]:
+        return [Context(v) for v in re.findall(r"\B@(\S+)\b", self.text)]
+
+    @functools.cached_property
+    def projects(self) -> list[Project]:
+        return [Project(v) for v in re.findall(r"\B\+(\S+)\b", self.text)]
+
+    @functools.cached_property
+    def attrs(self) -> dict[str, str | datetime.date]:
+        d: dict[str, str | datetime.date] = {}
         for k, v in re.findall(r"([^\s:]+):([^\s:]+)", self.text):
             if k == "pri":
-                self.priority = Priority[v]
-            else:
-                try:
-                    v = datetime.date.fromisoformat(v)
-                except ValueError:
-                    pass
-                self.attrs[k] = v
+                continue
+            try:
+                v = datetime.date.fromisoformat(v)
+            except ValueError:
+                pass
+            self.attrs[k] = v
+        return d
 
     def __eq__(self, other):
         if not hasattr(other, "text"):

--- a/tests/test_modification.py
+++ b/tests/test_modification.py
@@ -1,0 +1,21 @@
+import penelopise
+
+
+def test_noop_identical():
+    """Text changes should invalidate computed properties.
+
+    This abuses ``Entry`` in a bad way, but it is a quick way to see that we’re
+    avoiding expensive nad unnecessary invalidation of properties.
+    """
+    e = penelopise.Entry("example")
+    e.contexts = True  # type: ignore
+    e.text = e.text
+    assert e.contexts is True
+
+
+def test_properties_invalidate_on_change():
+    """Text changes should invalidate computed properties."""
+    e = penelopise.Entry("example with @context")
+    assert e.contexts == ["context"]
+    e.text = "dropped context"
+    assert not e.contexts

--- a/tests/test_modification.py
+++ b/tests/test_modification.py
@@ -1,12 +1,13 @@
 import penelopise
 
 
-def test_noop_identical():
+def test_noop_identical(monkeypatch):
     """Text changes should invalidate computed properties.
 
     This abuses ``Entry`` in a bad way, but it is a quick way to see that we’re
     avoiding expensive nad unnecessary invalidation of properties.
     """
+    monkeypatch.delattr(penelopise.Entry, "contexts")
     e = penelopise.Entry("example")
     e.contexts = True  # type: ignore
     e.text = e.text


### PR DESCRIPTION
This is an alternate path forward.

It also *hugely* impacts performance, in a manner very different from #3. Initial read is instant, but processing `Entries()` becomes far less predictable.

I'm unsure if this is the correct route, so I'm going to open PRs in things that are using `penelopise` to see how it changes things. Once those have shaken for a little while the next step `should` be obvious.

[*Note*: This is duplicate of #6; as GitHub automatically closed by the PR after a branch reshuffle.]
